### PR TITLE
Remove Nokogiri dependency

### DIFF
--- a/lib/u_torrent.rb
+++ b/lib/u_torrent.rb
@@ -1,7 +1,6 @@
 require 'cgi'
 require 'uri'
 require 'net/http'
-require 'nokogiri'
 require 'json'
 require_relative 'u_torrent/configuration'
 require_relative 'u_torrent/http'

--- a/lib/u_torrent/http.rb
+++ b/lib/u_torrent/http.rb
@@ -45,7 +45,7 @@ module UTorrent
 
       response = get(uri)
 
-      @token = Nokogiri::HTML(response.body).at_xpath('//div').content
+      @token = response.body.gsub(/<[^<>]+>/, '')
       @cookie = response['set-cookie']
     end
 

--- a/utorrent-webapi-ruby.gemspec
+++ b/utorrent-webapi-ruby.gemspec
@@ -20,5 +20,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.required_ruby_version = '~> 2.0'
-  spec.add_dependency 'nokogiri', '~> 1.6.7.0'
 end


### PR DESCRIPTION
Nokogiri is a pretty big dependency to only use once. The token.html response is small enough that I feel confident using this regex to strip everything except the token.